### PR TITLE
feat: 複数ファイル一括アップロード機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@
 - タグ管理システム（タグの作成/削除/ファイルへの付与）
 - ファイル検索・フィルタリング（名前、メタデータ、タグ、ファイルタイプで検索）
 - ファイルプレビュー機能（画像、PDF、テキストファイル対応）
+- 複数ファイル一括アップロード機能（最大10ファイルまで）
 
 #### 🚧 未実装機能
-- 複数ファイル一括アップロード
 - ユーザープロフィール編集
 - パスワード変更機能
 - ファイルの公開/非公開設定
@@ -114,16 +114,7 @@ web-storage-service/
 
 ## 次の開発ステップ（推奨順）
 
-### 1. 複数ファイルの一括アップロード
-```typescript
-// multerの設定をarrayに変更
-upload.array('files', 10) // 最大5ファイルまで
-
-// フロントエンドで複数選択対応
-<input type="file" multiple />
-```
-
-### 2. ユーザープロフィール編集
+### 1. ユーザープロフィール編集
 ```typescript
 // backend/src/routes/users.ts を新規作成
 router.put('/profile', authenticateToken, async (req, res) => {
@@ -131,7 +122,7 @@ router.put('/profile', authenticateToken, async (req, res) => {
 });
 ```
 
-### 3. パスワード変更機能
+### 2. パスワード変更機能
 ```typescript
 // backend/src/routes/auth.ts に追加
 router.post('/change-password', authenticateToken, async (req, res) => {
@@ -140,14 +131,14 @@ router.post('/change-password', authenticateToken, async (req, res) => {
 });
 ```
 
-### 4. ファイルの公開/非公開設定
+### 3. ファイルの公開/非公開設定
 ```typescript
 // filesテーブルにis_publicカラムを追加
 // 公開URL生成機能
 // アクセス制御の実装
 ```
 
-### 5. フォルダ機能
+### 4. フォルダ機能
 ```typescript
 // foldersテーブルの作成
 // フォルダ階層の管理
@@ -264,7 +255,7 @@ VITE_API_URL=http://localhost:3001
 - [x] タグ管理システム ✅ 実装済み
 - [x] 検索・フィルタリング機能 ✅ 実装済み
 - [x] ファイルプレビュー機能 ✅ 実装済み
-- [ ] 複数ファイル一括アップロード
+- [x] 複数ファイル一括アップロード ✅ 実装済み
 - [ ] ユーザープロフィール編集
 - [ ] パスワード変更機能
 - [ ] ファイルの公開/非公開設定
@@ -286,15 +277,14 @@ VITE_API_URL=http://localhost:3001
 
 ## 最後に開発したセッションの情報
 
-- **日時**: 2025-09-17
+- **日時**: 2025-09-18
 - **実装内容**:
-  - ファイルプレビュー機能（画像、PDF、テキストファイル対応）
-  - FilePreviewコンポーネントの作成
-  - プレビューAPIエンドポイントの追加（/api/files/:id/preview）
-  - 認証ミドルウェアの改善（クエリパラメータでのトークンサポート）
-  - lucide-reactアイコンライブラリの追加
-- **ブランチ**: feature/file-preview
-- **次回予定**: 複数ファイル一括アップロード機能またはユーザープロフィール編集機能の実装を推奨
+  - 複数ファイル一括アップロード機能（最大10ファイルまで）
+  - バックエンドAPIエンドポイントの追加（/api/files/upload-multiple）
+  - フロントエンドUIの改善（単一/複数アップロードのセクション分離）
+  - エラーハンドリングの実装（一部ファイルが失敗しても正常ファイルはアップロード）
+- **ブランチ**: feature/multiple-file-upload
+- **次回予定**: ユーザープロフィール編集機能またはパスワード変更機能の実装を推奨
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,18 @@ docker-compose up -d
 
 ### ファイルのアップロード
 
-1. ダッシュボードの「File Upload」セクションで「Choose File」をクリック
+#### 単一ファイルのアップロード
+1. ダッシュボードの「Single File Upload」セクションで「Choose File」をクリック
 2. アップロードしたいファイルを選択
 3. 「Upload File」ボタンをクリック
 4. アップロード完了後、ファイル一覧に表示される
+
+#### 複数ファイルの一括アップロード
+1. ダッシュボードの「Multiple Files Upload」セクションで「Choose Files」をクリック
+2. 複数のファイルを選択（最大10ファイルまで）
+3. 選択されたファイル一覧と合計サイズを確認
+4. 「Upload X Files」ボタンをクリック
+5. アップロード完了後、ファイル一覧に表示される
 
 ### ファイルのダウンロード
 
@@ -226,9 +234,13 @@ docker-compose exec frontend sh
 
 #### ファイル管理
 
-- `POST /api/files/upload` - ファイルアップロード（要認証）
+- `POST /api/files/upload` - 単一ファイルアップロード（要認証）
   - multipart/form-data
   - フィールド: `file`, `metadata`（オプション）
+
+- `POST /api/files/upload-multiple` - 複数ファイル一括アップロード（要認証）
+  - multipart/form-data
+  - フィールド: `files[]`（最大10ファイル）, `metadata`（オプション）
 
 - `GET /api/files` - ファイル一覧取得（要認証）
 
@@ -325,7 +337,7 @@ docker-compose build --no-cache
 - [x] メタデータ編集機能
 - [x] ファイルのダウンロード機能
 - [x] ファイルの削除機能
-- [ ] 複数ファイルの一括アップロード
+- [x] 複数ファイルの一括アップロード
 - [ ] ユーザープロフィール編集
 - [ ] パスワード変更機能
 - [ ] ファイルの公開/非公開設定

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -51,6 +51,17 @@ export const fileService = {
     const response = await api.post('/api/files/upload', formData)
     return response.data
   },
+  uploadMultiple: async (files: File[], metadata?: any) => {
+    const formData = new FormData()
+    files.forEach(file => {
+      formData.append('files', file)
+    })
+    if (metadata) {
+      formData.append('metadata', JSON.stringify(metadata))
+    }
+    const response = await api.post('/api/files/upload-multiple', formData)
+    return response.data
+  },
   getFiles: async () => {
     const response = await api.get('/api/files')
     return response.data


### PR DESCRIPTION
- 最大10ファイルまで同時アップロード可能
- バックエンドに/api/files/upload-multipleエンドポイントを追加
- フロントエンドUIを単一/複数アップロードのセクションに分離
- エラーハンドリング実装（一部失敗しても成功分はアップロード）
- 選択ファイル一覧と合計サイズ表示機能を追加
- README.mdとCLAUDE.mdのドキュメントを更新

🤖 Generated with [Claude Code](https://claude.ai/code)